### PR TITLE
Create .rubocop-3-1.yml

### DIFF
--- a/.rubocop-3-1.yml
+++ b/.rubocop-3-1.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - https://raw.githubusercontent.com/GetTerminus/ruby_shared_configs/master/.rubocop.yml
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either


### PR DESCRIPTION
`deep-cover` gem doesn't support new shorthand: https://github.com/GetTerminus/creative_asset_library/runs/5248888624?check_suite_focus=true